### PR TITLE
Fix autofix for `options` and `multiOptions` sorting rules

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -195,3 +195,25 @@ export const CREDS_EXEMPTED_FROM_API_SUFFIX = [
 	"SshPrivateKey",
 	"TimescaleDb",
 ];
+
+// ----------------------------------
+//            formatting
+// ----------------------------------
+
+/**
+ * From: https://raw.githubusercontent.com/n8n-io/n8n/master/.prettierrc.js
+ */
+ export const PRETTIER_CONFIG = {
+	semi: true,
+	trailingComma: 'all',
+	bracketSpacing: true,
+	useTabs: true,
+	tabWidth: 2,
+	arrowParens: 'always',
+	singleQuote: true,
+	quoteProps: 'as-needed',
+	endOfLine: 'lf',
+	printWidth: 100,
+
+	parser: 'babel' // to silence warning, not part of n8n's config
+} as const;

--- a/lib/rules/node-param-multi-options-type-unsorted-items.ts
+++ b/lib/rules/node-param-multi-options-type-unsorted-items.ts
@@ -1,3 +1,4 @@
+import prettier from "prettier";
 import {
 	MIN_ITEMS_TO_ALPHABETIZE,
 	MIN_ITEMS_TO_ALPHABETIZE_SPELLED_OUT,
@@ -5,6 +6,8 @@ import {
 import { utils } from "../ast/utils";
 import { id } from "../ast/identifiers";
 import { getters } from "../ast/getters";
+import { PRETTIER_CONFIG } from "../constants";
+import { toOptions } from "./node-param-options-type-unsorted-items";
 
 export default utils.createRule({
 	name: utils.getRuleName(module),
@@ -29,26 +32,45 @@ export default utils.createRule({
 
 				if (!id.nodeParam.isMultiOptionsType(node)) return;
 
-				const options = getters.nodeParam.getOptions(node);
+				const optionsNode = getters.nodeParam.getOptions(node);
+
+				if (!optionsNode) return;
+
+				if (optionsNode.value.length < MIN_ITEMS_TO_ALPHABETIZE) return;
+
+				if (/^\d+$/.test(optionsNode.value[0].value)) return; // do not sort numeric strings
+
+				const optionsSource = context
+					.getSourceCode()
+					.getText(optionsNode.ast.value);
+
+				const options = toOptions(optionsSource);
 
 				if (!options) return;
 
-				if (options.value.length < MIN_ITEMS_TO_ALPHABETIZE) return;
+				const sortedOptions = [...options].sort(utils.optionComparator);
 
-				const sortedOptions = [...options.value].sort(utils.optionComparator);
-
-				if (!utils.areIdenticallySortedOptions(options.value, sortedOptions)) {
-					const baseIndentation = utils.getBaseIndentationForOption(options);
-
-					const fixed = utils.formatItems(sortedOptions, baseIndentation);
-
+				if (!utils.areIdenticallySortedOptions(options, sortedOptions)) {
 					const displayOrder = utils.toDisplayOrder(sortedOptions);
+
+					const sortedOptionsSource = JSON.stringify(sortedOptions, null, 2);
+
+					const unformattedNewSource = context
+						.getSourceCode()
+						.getText()
+						.replace(optionsSource, sortedOptionsSource);
+
+					const formattedNewSource = prettier
+						.format(unformattedNewSource, PRETTIER_CONFIG)
+						.trim(); // consume Prettier's EoF newline
+
+					const fullAst = context.getSourceCode().ast;
 
 					context.report({
 						messageId: "sortItems",
-						node: options.ast,
+						node: optionsNode.ast,
 						data: { displayOrder },
-						fix: (fixer) => fixer.replaceText(options.ast, `options: ${fixed}`),
+						fix: (fixer) => fixer.replaceText(fullAst, formattedNewSource),
 					});
 				}
 			},

--- a/lib/rules/node-param-options-type-unsorted-items.ts
+++ b/lib/rules/node-param-options-type-unsorted-items.ts
@@ -1,3 +1,4 @@
+import prettier from "prettier";
 import {
 	MIN_ITEMS_TO_ALPHABETIZE,
 	MIN_ITEMS_TO_ALPHABETIZE_SPELLED_OUT,
@@ -5,6 +6,7 @@ import {
 import { utils } from "../ast/utils";
 import { id } from "../ast/identifiers";
 import { getters } from "../ast/getters";
+import { PRETTIER_CONFIG } from "../constants";
 
 export default utils.createRule({
 	name: utils.getRuleName(module),
@@ -29,31 +31,57 @@ export default utils.createRule({
 
 				if (!id.nodeParam.isOptionsType(node)) return;
 
-				const options = getters.nodeParam.getOptions(node);
+				const optionsNode = getters.nodeParam.getOptions(node);
+
+				if (!optionsNode) return;
+
+				if (optionsNode.value.length < MIN_ITEMS_TO_ALPHABETIZE) return;
+
+				if (/^\d+$/.test(optionsNode.value[0].value)) return; // do not sort numeric strings
+
+				const optionsSource = context
+					.getSourceCode()
+					.getText(optionsNode.ast.value);
+
+				const options = toOptions(optionsSource);
 
 				if (!options) return;
 
-				if (options.value.length < MIN_ITEMS_TO_ALPHABETIZE) return;
+				const sortedOptions = [...options].sort(utils.optionComparator);
 
-				if (/^\d+$/.test(options.value[0].value)) return; // do not sort numeric strings
-
-				const sortedOptions = [...options.value].sort(utils.optionComparator);
-
-				if (!utils.areIdenticallySortedOptions(options.value, sortedOptions)) {
-					const baseIndentation = utils.getBaseIndentationForOption(options);
-
-					const fixed = utils.formatItems(sortedOptions, baseIndentation);
-
+				if (!utils.areIdenticallySortedOptions(options, sortedOptions)) {
 					const displayOrder = utils.toDisplayOrder(sortedOptions);
+
+					const sortedOptionsSource = JSON.stringify(sortedOptions, null, 2);
+
+					const unformattedNewSource = context
+						.getSourceCode()
+						.getText()
+						.replace(optionsSource, sortedOptionsSource);
+
+					const formattedNewSource = prettier
+						.format(unformattedNewSource, PRETTIER_CONFIG)
+						.trim(); // consume Prettier's EoF newline
+
+					const fullAst = context.getSourceCode().ast;
 
 					context.report({
 						messageId: "sortItems",
-						node: options.ast,
+						node: optionsNode.ast,
 						data: { displayOrder },
-						fix: (fixer) => fixer.replaceText(options.ast, `options: ${fixed}`),
+						fix: (fixer) => fixer.replaceText(fullAst, formattedNewSource),
 					});
 				}
 			},
 		};
 	},
 });
+
+export function toOptions(optionsSource: string): Array<{ name: string }> | null {
+	try {
+		return eval(`(${optionsSource})`);
+	} catch (error) {
+		console.error("Failed to eval options source", optionsSource, error);
+		return null;
+	}
+}

--- a/tests/node-param-multi-options-type-unsorted-items.test.ts
+++ b/tests/node-param-multi-options-type-unsorted-items.test.ts
@@ -168,7 +168,7 @@ ruleTester().run(getRuleName(module), rule, {
 					{
 						name: 'Date Equal',
 						value: 'date_equal',
-						description: 'Field is date. Format: \\'YYYY-MM-DD\\'',
+						description: "Field is date. Format: 'YYYY-MM-DD'",
 					},
 					{
 						name: 'Invoice Deleted',
@@ -178,12 +178,13 @@ ruleTester().run(getRuleName(module), rule, {
 					{
 						name: 'Invoice Generated',
 						value: 'invoice_generated',
-						description: 'Event triggered when a new invoice is generated. In case of metered billing, this event is triggered when a \\'Pending\\' invoice is closed.',
+						description:
+							'Event triggered when a new invoice is generated. In case of metered billing, this event is triggered when a "Pending" invoice is closed.',
 					},
 					{
 						name: 'Subscription Renewal Reminder',
 						value: 'subscription_renewal_reminder',
-						description: 'Triggered 3 days before each subscription\\'s renewal.',
+						description: "Triggered 3 days before each subscription's renewal.",
 					},
 					{
 						name: 'Transaction Created',
@@ -198,7 +199,8 @@ ruleTester().run(getRuleName(module), rule, {
 					{
 						name: 'Transaction Updated',
 						value: 'transaction_updated',
-						description: 'Triggered when a transaction is updated. E.g. (1) When a transaction is removed, (2) or when an excess payment is applied on an invoice, (3) or when amount_capturable gets updated.',
+						description:
+							'Triggered when a transaction is updated. E.g. (1) When a transaction is removed, (2) or when an excess payment is applied on an invoice, (3) or when amount_capturable gets updated.',
 					},
 				],
 			};`,


### PR DESCRIPTION
Restore source from context and format sorted options with Prettier in
- `node-param-options-type-unsorted-items`
- `node-param-multi-options-type-unsorted-itemsts`

Close #116