### PR TITLE
Switch Prettier parser to `babel-ts`

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -215,5 +215,5 @@ export const CREDS_EXEMPTED_FROM_API_SUFFIX = [
 	endOfLine: 'lf',
 	printWidth: 100,
 
-	parser: 'babel' // to silence warning, not part of n8n's config
+	parser: 'babel-ts' // to silence warning, not part of n8n's config
 } as const;

--- a/lib/rules/node-param-options-type-unsorted-items.ts
+++ b/lib/rules/node-param-options-type-unsorted-items.ts
@@ -81,7 +81,6 @@ export function toOptions(optionsSource: string): Array<{ name: string }> | null
 	try {
 		return eval(`(${optionsSource})`);
 	} catch (error) {
-		console.error("Failed to eval options source", optionsSource, error);
 		return null;
 	}
 }


### PR DESCRIPTION
Also remove logging for `eval` unable to parse vars in object literal, e.g. `preSend: [validEmailAndPhonePreSendAction, splitTagsPreSendAction]`